### PR TITLE
Install dependencies with --sync

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,4 +56,4 @@ runs:
 
     - name: Install
       shell: bash
-      run: poetry install ${{ inputs.INSTALL_ARGS }}
+      run: poetry install ${{ inputs.INSTALL_ARGS }} --sync


### PR DESCRIPTION
If we hit a cache entry with a package installed, we should make sure we remove it.

CC @lochsh 