### PR TITLE
Use GHA_TOKEN when checking out

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,7 @@ runs:
         fetch-depth: 0
         submodules: recursive
         lfs: true
+        token: ${{ inputs.GHA_TOKEN }}
 
     - name: LFS checkout
       shell: bash


### PR DESCRIPTION
https://oxionics.slack.com/archives/C02TBJJNC3U/p1693999865796699

Without this we seen issues when checking out submodules.