### PR TITLE
Remove fallback cache key

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,6 @@ runs:
         key: poetry-${{ runner.os }}-py${{ inputs.PYTHON_VERSION }}-${{ hashFiles('**/poetry.lock') }}
         restore-keys: |
           poetry-${{ runner.os }}-py${{ inputs.PYTHON_VERSION }}-${{ hashFiles('**/poetry.lock') }}
-          poetry-${{ runner.os }}-py${{ inputs.PYTHON_VERSION }}-
 
     - name: Install
       shell: bash


### PR DESCRIPTION
We think we've seen cases where we've seen GHA restore a cache which contains a package installed which has subsequently had an invalid entry added to the poetry lock file. This allows CI to pass with an invalid poetry lock file. If we only restore the cache when the poetry.lock file matches this should avoid this.