### PR TITLE
Update actions to latest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: recursive
@@ -47,7 +47,7 @@ runs:
         poetry env use ${{ inputs.PYTHON_VERSION }}
 
     - name: Cache virtualenv
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ./.venv
         key: poetry-${{ runner.os }}-py${{ inputs.PYTHON_VERSION }}-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
GitHub actions have deprecated Node 16 in favour of Node 20, and so we need to bump a bunch of actions too.  See also OxIonics/common-workflows#56.