### PR TITLE
Increase poetry timeouts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,3 +57,6 @@ runs:
     - name: Install
       shell: bash
       run: poetry install ${{ inputs.INSTALL_ARGS }} --sync
+      env:
+        PIP_REQUESTS_TIMEOUT: 300
+        POETRY_REQUESTS_TIMEOUT: 300


### PR DESCRIPTION
Maybe some of the poetry problems we see in CI are poetry timing out rather than server issues:

Some of them look like this, which seems to support that:
```
  ReadTimeout

  HTTPConnectionPool(host='pypi.oxionics.com', port=3141): Read timed out. (read timeout=15)
```

So maybe we should try: https://python-poetry.org/docs/faq#my-requests-are-timing-out

I have no way to test this but I'm tempted to just yolo it.